### PR TITLE
define json object mapper as the primary bean instead of an xml object mapper

### DIFF
--- a/service/src/main/java/tds/support/tool/configuration/SupportToolServiceConfiguration.java
+++ b/service/src/main/java/tds/support/tool/configuration/SupportToolServiceConfiguration.java
@@ -5,11 +5,13 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +19,6 @@ import java.util.Map;
 import tds.common.configuration.JacksonObjectMapperConfiguration;
 import tds.common.configuration.SecurityConfiguration;
 import tds.common.web.advice.ExceptionAdvice;
-import tds.support.tool.handlers.loader.TestPackageFileHandler;
 import tds.support.tool.handlers.loader.TestPackageHandler;
 
 @Configuration
@@ -43,10 +44,16 @@ public class SupportToolServiceConfiguration {
         return new HashMap<>();
     }
 
-    @Bean
+    @Bean(name = "xmlMapper")
     public XmlMapper getXmlMapper() {
         final XmlMapper xmlMapper = new XmlMapper();
         xmlMapper.registerModule(new Jdk8Module());
         return xmlMapper;
+    }
+
+    @Primary
+    @Bean
+    public ObjectMapper getObjectMapper() {
+        return new ObjectMapper();
     }
 }


### PR DESCRIPTION
The class tds.common.configuration.JacksonObjectMapperConfiguration was being provided
the wrong bean instance.  The xml mapper bean used to deserialize to map rest responses.

Created a new json object mapper as the primary bean for rest response mapping.