### PR TITLE
change context root of support tool

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -19,6 +19,7 @@ security:
 
 server:
   port: 8080
+  context-path: /supporttool
   undertow:
     buffer-size: 16384
     io-threads: 64

--- a/service/src/main/webapp/package.json
+++ b/service/src/main/webapp/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
-    "prod": "node ./node_modules/.bin/ng build --prod",
+    "prod": "node ./node_modules/.bin/ng build --prod --base-href /supporttool/",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
The support tool is deployed in the same k8 cluster as student, proctor apps.
Setting the default context root to '/supporttool'.

Note that k8 ingress configuration could be used to accomplish the same effect:
annotations:
    ingress.kubernetes.io/add-base-url: "true"
    ingress.kubernetes.io/rewrite-target: /

Except that in the current k8 configuration, the add-base-url annotation did not
rewrite the base-url html tag.