### PR TITLE
Fix refresh of angular app served by spring boot

### DIFF
--- a/service/src/main/java/tds/support/tool/TdsSupportToolApplication.java
+++ b/service/src/main/java/tds/support/tool/TdsSupportToolApplication.java
@@ -2,9 +2,16 @@ package tds.support.tool;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @SpringBootApplication
+@Controller
 public class TdsSupportToolApplication {
+    @GetMapping(value = "/{path:[^\\.]*}")
+    public String redirect() {
+        return "forward:/";
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(TdsSupportToolApplication.class, args);


### PR DESCRIPTION
Angular apps use url paths to store application state.
Configure spring boot to redirect urls to root path of angular app.