### PR TITLE
add scoring rules with references to blueprint elements that do not e…

### DIFF
--- a/client/src/main/java/tds/testpackage/model/BlueprintElementTypes.java
+++ b/client/src/main/java/tds/testpackage/model/BlueprintElementTypes.java
@@ -30,6 +30,7 @@ public interface BlueprintElementTypes {
     String SEGMENT = "segment";
     String TEST = "test";
     String PACKAGE = "package";
+    String UNKNOWN = "unknown";
 
     Set<String> CLAIM_AND_TARGET_TYPES = ImmutableSet.of(STRAND, CONTENT_LEVEL, TARGET, CLAIM);
     Set<String> CLAIM_TYPES = ImmutableSet.of(STRAND, CLAIM);


### PR DESCRIPTION
…xist

Some scoring rules contain references to blueprint elements that do not exist.
TIS requires these scoring rules and sets the blueprint element name as the reference id.
Add a mapping to create a blueprint element if there is a reference to a non-existing blueprint.