### PR TITLE
Fix bug TDS-1558: ART error loading/delete tests from TSB.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/service/src/main/java/tds/support/tool/services/impl/ARTTestPackageServiceImpl.java
+++ b/service/src/main/java/tds/support/tool/services/impl/ARTTestPackageServiceImpl.java
@@ -15,7 +15,6 @@ import tds.common.ValidationError;
 import tds.common.web.resources.NoContentResponseResource;
 import tds.support.tool.configuration.SupportToolProperties;
 import tds.support.tool.services.ARTTestPackageService;
-import tds.support.tool.utils.TestPackageUtils;
 import tds.testpackage.model.TestPackage;
 
 @Service
@@ -59,8 +58,8 @@ public class ARTTestPackageServiceImpl implements ARTTestPackageService {
                         .fromHttpUrl(String.format("%s/tsbassessment",
                                 properties.getArtRestUrl().get()));
 
-        testPackage.getAssessments().forEach(assessment ->
-                builder.queryParam("assessmentKey", TestPackageUtils.getAssessmentKey(testPackage, assessment.getId())));
+        // The 'assessmentKey' in our request should be the shorter ID, not the real full Key.
+        testPackage.getAssessments().forEach(assessment -> builder.queryParam("assessmentKey", assessment.getId()));
 
         restTemplate.delete(builder.build().toUri());
     }


### PR DESCRIPTION
Specifically changes provided key value to just be the ID, which is what
TSB wants.

Also add annoying package-lock.json file, which is intended to be
checked in and helps keep installed node versions in sync across devs.