### PR TITLE
Adding endpoints for fetching original trt, rescored trt, and scoring…

### DIFF
--- a/client/src/main/java/tds/support/job/ScoringValidationReport.java
+++ b/client/src/main/java/tds/support/job/ScoringValidationReport.java
@@ -1,0 +1,18 @@
+package tds.support.job;
+
+public class ScoringValidationReport {
+    //TODO: Remove this property - only added because Spring REST cannot serialize blank classes
+    private String removeThis;
+
+    public ScoringValidationReport() {
+    }
+
+
+    public String getRemoveThis() {
+        return removeThis;
+    }
+
+    public void setRemoveThis(final String removeThis) {
+        this.removeThis = removeThis;
+    }
+}

--- a/client/src/main/java/tds/support/job/TestResultsWrapper.java
+++ b/client/src/main/java/tds/support/job/TestResultsWrapper.java
@@ -1,10 +1,12 @@
 package tds.support.job;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
 import tds.trt.model.TDSReport;
 
 import javax.xml.bind.annotation.*;
 
+@Document(collection = "testResults")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "TestResults")
 public class TestResultsWrapper {
@@ -16,6 +18,10 @@ public class TestResultsWrapper {
 
     @XmlElement(name = "TDSReport")
     private TDSReport testResults;
+
+    private TDSReport rescoredTestResults;
+
+    private ScoringValidationReport scoringValidationReport;
 
     private TestResultsWrapper() {
 
@@ -36,5 +42,21 @@ public class TestResultsWrapper {
 
     public String getJobId() {
         return jobId;
+    }
+
+    public TDSReport getRescoredTestResults() {
+        return rescoredTestResults;
+    }
+
+    public void setRescoredTestResults(final TDSReport rescoredTestResults) {
+        this.rescoredTestResults = rescoredTestResults;
+    }
+
+    public ScoringValidationReport getScoringValidationReport() {
+        return scoringValidationReport;
+    }
+
+    public void setScoringValidationReport(final ScoringValidationReport scoringValidationReport) {
+        this.scoringValidationReport = scoringValidationReport;
     }
 }

--- a/service/src/main/java/tds/support/tool/repositories/scoring/MongoTestResultsRepository.java
+++ b/service/src/main/java/tds/support/tool/repositories/scoring/MongoTestResultsRepository.java
@@ -4,4 +4,10 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import tds.support.job.TestResultsWrapper;
 
 public interface MongoTestResultsRepository extends MongoRepository<TestResultsWrapper, String> {
+    /**
+     * Finds an original TRT based on the job id
+     * @param jobId The jobId of original TRT
+     * @return The original TRT {@link tds.trt.model.TDSReport} wrapped object
+     */
+    TestResultsWrapper findByJobId(final String jobId);
 }

--- a/service/src/main/java/tds/support/tool/services/TestResultsJobService.java
+++ b/service/src/main/java/tds/support/tool/services/TestResultsJobService.java
@@ -3,9 +3,12 @@ package tds.support.tool.services;
 import org.springframework.security.access.prepost.PreAuthorize;
 import tds.support.job.Job;
 import tds.support.job.JobUpdateRequest;
+import tds.support.job.ScoringValidationReport;
+import tds.trt.model.TDSReport;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 
 public interface TestResultsJobService {
 
@@ -29,9 +32,48 @@ public interface TestResultsJobService {
 
     /**
      * Returns all scoring validation jobs
+     *
      * @return A list of all scoring validation {@link Job}s
      */
     List<Job> findJobs();
 
+    /**
+     * Updates the status of a test package job
+     *
+     * @param jobId   The id of the job to update
+     * @param request an object with status information
+     */
     void updateJob(final String jobId, final JobUpdateRequest request);
+
+    /**
+     * Returns a specific scoring validation job
+     *
+     * @param jobId The id of the job to fetch
+     * @return The job with the specified jobId, if it exists
+     */
+    Optional<Job> findJob(final String jobId);
+
+    /**
+     * Finds the original TRT uploaded for the specified job
+     *
+     * @param jobId The job id of the TRT
+     * @return The TRT
+     */
+    Optional<TDSReport> findOriginalTrt(final String jobId);
+
+    /**
+     * Finds the rescored TRT uploaded for the specified job
+     *
+     * @param jobId The job id of the TRT
+     * @return The TRT
+     */
+    Optional<TDSReport> findRescoredTrt(final String jobId);
+
+    /**
+     * Finds the scoring validation report for the specified job
+     *
+     * @param jobId The id of the job the report was generated for
+     * @return The scoring validation report
+     */
+    Optional<ScoringValidationReport> findScoringValidationReport(String jobId);
 }

--- a/service/src/main/java/tds/support/tool/services/impl/TestResultsMarshaller.java
+++ b/service/src/main/java/tds/support/tool/services/impl/TestResultsMarshaller.java
@@ -1,0 +1,24 @@
+package tds.support.tool.services.impl;
+
+import org.springframework.stereotype.Service;
+import tds.trt.model.TDSReport;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.StringWriter;
+
+@Service
+public class TestResultsMarshaller {
+
+    public static String mashall(final TDSReport testResults) throws JAXBException {
+        final JAXBContext context = JAXBContext.newInstance(TDSReport.class);
+        final Marshaller marshaller = context.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+        final StringWriter sw = new StringWriter();
+
+        marshaller.marshal(testResults, sw);
+
+        return sw.toString();
+    }
+}

--- a/service/src/main/java/tds/support/tool/web/ScoringValidationController.java
+++ b/service/src/main/java/tds/support/tool/web/ScoringValidationController.java
@@ -8,10 +8,15 @@ import org.springframework.web.multipart.MultipartFile;
 import tds.common.web.resources.NoContentResponseResource;
 import tds.support.job.Job;
 import tds.support.job.JobUpdateRequest;
+import tds.support.job.ScoringValidationReport;
 import tds.support.tool.services.TestResultsJobService;
+import tds.support.tool.services.impl.TestResultsMarshaller;
+import tds.trt.model.TDSReport;
 
+import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/scoring")
@@ -45,6 +50,72 @@ public class ScoringValidationController {
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<Job>> getJobs() {
         return ResponseEntity.ok(testResultsJobService.findJobs());
+    }
+
+    /**
+     * Gets a specific scoring job
+     *
+     * @return {@link org.springframework.http.ResponseEntity} containing the new {@link tds.support.job.Job}
+     * @throws IOException thrown if there is an issue with accessing the file
+     */
+    @GetMapping(value = "/{jobId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Job> getJob(@PathVariable final String jobId) {
+        Optional<Job> maybeJob = testResultsJobService.findJob(jobId);
+
+        if (!maybeJob.isPresent()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(maybeJob.get());
+    }
+
+
+    /**
+     * Gets an original TRT uploaded with the specified job
+     *
+     * @return {@link org.springframework.http.ResponseEntity} containing the original stringified {@link TDSReport}
+     */
+    @GetMapping(value = "/{jobId}/original", produces = MediaType.APPLICATION_XML_VALUE)
+    public ResponseEntity<String> getOriginalTrt(@PathVariable final String jobId) throws JAXBException {
+        Optional<TDSReport> maybeTrt = testResultsJobService.findOriginalTrt(jobId);
+
+        if (!maybeTrt.isPresent()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(TestResultsMarshaller.mashall(maybeTrt.get()));
+    }
+
+    /**
+     * Gets a specific scoring job
+     *
+     * @return {@link org.springframework.http.ResponseEntity} containing the rescored stringified {@link TDSReport}
+     */
+    @GetMapping(value = "/{jobId}/rescored", produces = MediaType.APPLICATION_XML_VALUE)
+    public ResponseEntity<String> getRescoredTrt(@PathVariable final String jobId) throws JAXBException {
+        Optional<TDSReport> maybeTrt = testResultsJobService.findRescoredTrt(jobId);
+
+        if (!maybeTrt.isPresent()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(TestResultsMarshaller.mashall(maybeTrt.get()));
+    }
+
+    /**
+     * Gets a specific scoring job
+     *
+     * @return {@link org.springframework.http.ResponseEntity} containing the rescored stringified {@link TDSReport}
+     */
+    @GetMapping(value = "/{jobId}/report", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ScoringValidationReport> getScoringValidationReport(@PathVariable final String jobId) {
+        Optional<ScoringValidationReport> maybeReport = testResultsJobService.findScoringValidationReport(jobId);
+
+        if (!maybeReport.isPresent()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(maybeReport.get());
     }
 
     /**

--- a/service/src/test/java/tds/support/tool/web/ScoringValidationControllerIntegrationTests.java
+++ b/service/src/test/java/tds/support/tool/web/ScoringValidationControllerIntegrationTests.java
@@ -13,21 +13,28 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import tds.common.configuration.SecurityConfiguration;
 import tds.common.web.advice.ExceptionAdvice;
+import tds.support.job.Job;
 import tds.support.job.JobUpdateRequest;
+import tds.support.job.ScoringValidationReport;
 import tds.support.job.TestResultsScoringJob;
 import tds.support.tool.services.TestResultsJobService;
+import tds.trt.model.TDSReport;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(ScoringValidationController.class)
@@ -66,4 +73,109 @@ public class ScoringValidationControllerIntegrationTests {
         verify(mockTestResultsJobService).updateJob(eq("jobId"), isA(JobUpdateRequest.class));
     }
 
+    @Test
+    public void shouldGetScoringJob() throws Exception {
+        Job mockJob = new TestResultsScoringJob("name");
+        when(mockTestResultsJobService.findJob("jobId")).thenReturn(Optional.of(mockJob));
+
+        http.perform(MockMvcRequestBuilders.get(new URI("/api/scoring/jobId"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is(mockJob.getName())));
+
+        verify(mockTestResultsJobService).findJob("jobId");
+    }
+
+    @Test
+    public void shouldGet404ForNoJob() throws Exception {
+        when(mockTestResultsJobService.findJob("jobId")).thenReturn(Optional.empty());
+
+        http.perform(MockMvcRequestBuilders.get(new URI("/api/scoring/jobId"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+        verify(mockTestResultsJobService).findJob("jobId");
+    }
+
+    @Test
+    public void shouldGetOriginalTrt() throws Exception {
+        TDSReport originalTrt = new TDSReport();
+        TDSReport.Opportunity opportunity = new TDSReport.Opportunity();
+        opportunity.setClientName("SBAC");
+        opportunity.setKey("A key");
+        originalTrt.setOpportunity(opportunity);
+        when(mockTestResultsJobService.findOriginalTrt("jobId")).thenReturn(Optional.of(originalTrt));
+
+        http.perform(MockMvcRequestBuilders.get(new URI("/api/scoring/jobId/original"))
+                .contentType(MediaType.APPLICATION_XML))
+                .andExpect(status().isOk())
+                .andExpect(xpath("/TDSReport/Opportunity/@clientName").string("SBAC"))
+                .andExpect(xpath("/TDSReport/Opportunity/@key").string("A key"));
+
+        verify(mockTestResultsJobService).findOriginalTrt("jobId");
+    }
+
+    @Test
+    public void shouldGet404ForNoOriginalTrtFound() throws Exception {
+        when(mockTestResultsJobService.findOriginalTrt("jobId")).thenReturn(Optional.empty());
+
+        http.perform(MockMvcRequestBuilders.get(new URI("/api/scoring/jobId/original"))
+                .contentType(MediaType.APPLICATION_XML))
+                .andExpect(status().isNotFound());
+
+        verify(mockTestResultsJobService).findOriginalTrt("jobId");
+    }
+
+    @Test
+    public void shouldGetRescoredTrt() throws Exception {
+        TDSReport rescoredTrt = new TDSReport();
+        TDSReport.Opportunity opportunity = new TDSReport.Opportunity();
+        opportunity.setClientName("SBAC");
+        opportunity.setKey("A key");
+        rescoredTrt.setOpportunity(opportunity);
+        when(mockTestResultsJobService.findRescoredTrt("jobId")).thenReturn(Optional.of(rescoredTrt));
+
+        http.perform(MockMvcRequestBuilders.get(new URI("/api/scoring/jobId/rescored"))
+                .contentType(MediaType.APPLICATION_XML))
+                .andExpect(status().isOk())
+                .andExpect(xpath("/TDSReport/Opportunity/@clientName").string("SBAC"))
+                .andExpect(xpath("/TDSReport/Opportunity/@key").string("A key"));
+
+        verify(mockTestResultsJobService).findRescoredTrt("jobId");
+    }
+
+    @Test
+    public void shouldGet404ForNoRescoredTrtFound() throws Exception {
+        when(mockTestResultsJobService.findRescoredTrt("jobId")).thenReturn(Optional.empty());
+
+        http.perform(MockMvcRequestBuilders.get(new URI("/api/scoring/jobId/rescored"))
+                .contentType(MediaType.APPLICATION_XML))
+                .andExpect(status().isNotFound());
+
+        verify(mockTestResultsJobService).findRescoredTrt("jobId");
+    }
+
+    @Test
+    public void shouldGetScoringValidationReport() throws Exception {
+        when(mockTestResultsJobService.findScoringValidationReport("jobId"))
+                .thenReturn(Optional.of(new ScoringValidationReport()));
+
+        http.perform(MockMvcRequestBuilders.get(new URI("/api/scoring/jobId/report"))
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(mockTestResultsJobService).findScoringValidationReport("jobId");
+    }
+
+    @Test
+    public void shouldGet404ForNoScoringValidationReportFound() throws Exception {
+        when(mockTestResultsJobService.findScoringValidationReport("jobId")).thenReturn(Optional.empty());
+
+        http.perform(MockMvcRequestBuilders.get(new URI("/api/scoring/jobId/report"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+        verify(mockTestResultsJobService).findScoringValidationReport("jobId");
+    }
 }


### PR DESCRIPTION
… validation report.

At the moment, we are not filtering or taking into account user information - that will be implemented after externally-accessible secured endpoints are fixed, and as part of TDS-1681.

For the moment, I am stubbing out the ScoringValidationReport class.