### PR TITLE
serialize boolean as integer zero or one for isDemo field in TRT

### DIFF
--- a/client/src/main/java/tds/trt/model/TDSReport.java
+++ b/client/src/main/java/tds/trt/model/TDSReport.java
@@ -700,6 +700,7 @@ public class TDSReport {
         @XmlAttribute(name = "key")
         protected Long key;
         @XmlAttribute(name = "isDemo")
+        @XmlJavaTypeAdapter(ZeroOneBooleanAdapter.class)
         protected Boolean isDemo;
 
         /**

--- a/client/src/main/java/tds/trt/model/ZeroOneBooleanAdapter.java
+++ b/client/src/main/java/tds/trt/model/ZeroOneBooleanAdapter.java
@@ -1,0 +1,21 @@
+package tds.trt.model;
+
+import javax.xml.bind.DatatypeConverter;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+public class ZeroOneBooleanAdapter extends XmlAdapter<String, Boolean> {
+    public ZeroOneBooleanAdapter() {
+    }
+
+    public Boolean unmarshal(String v) {
+        return v == null ? null : DatatypeConverter.parseBoolean(v);
+    }
+
+    public String marshal(Boolean v) {
+        if (v == null) {
+            return null;
+        } else {
+            return v ? "1" : "0";
+        }
+    }
+}


### PR DESCRIPTION
When TIS deserialized the TRT, the isDemo attribute is expected to be zero or one instead of the string values "true" or "false"