### PR TITLE
Removed Opportunity id and key from difference report.

### DIFF
--- a/shared/src/main/java/tds/support/tool/services/scoring/impl/ScoringValidationServiceImpl.java
+++ b/shared/src/main/java/tds/support/tool/services/scoring/impl/ScoringValidationServiceImpl.java
@@ -70,8 +70,6 @@ public class ScoringValidationServiceImpl implements ScoringValidationService {
 
         Map<String, Object> diffs = new LinkedHashMap<>();
 
-        addDifferences("oppId", getDiffs(original.getOppId(), rescored.getOppId()), diffs);
-        addDifferences("key", getDiffs(original.getKey(), rescored.getKey()), diffs);
         addDifferences("scores", getScoreDiffs(original.getScore(), rescored.getScore()), diffs);
         addDifferences("items", getItemDiffs(original.getItem(), rescored.getItem()), diffs);
 


### PR DESCRIPTION
The change in Opportunity id is expected on rescore, so shouldn't be in the report. Opportunity key should never change.