### PR TITLE
fix link destination when clicking on home page logo

### DIFF
--- a/service/src/main/webapp/src/app/app.component.html
+++ b/service/src/main/webapp/src/app/app.component.html
@@ -10,7 +10,7 @@
         <!-- Navbar -->
         <nav class="navbar navbar-default">
           <div class="navbar-header">
-            <a class="navbar-brand hidden-xs" href="/" title="{{'application.home'}}"><img src="assets/image/SmarterBalanced-Logo.png" alt="{{'messages.organization'}}"></a>
+            <a class="navbar-brand hidden-xs" routerLink="/" title="{{'application.home'}}"><img src="assets/image/SmarterBalanced-Logo.png" alt="{{'messages.organization'}}"></a>
             <span class="application-title">{{title}}</span>
           </div>
           <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">


### PR DESCRIPTION
Link used with the logo was an absolute location.  When the app was deployed in k8 environment under a context path, the link was no longer valid.
The k8 ingress used to redirect that location to the support-tool.  The ingress has been updated an the re-direction removed.
Switching to using relative paths via angular routes.