### PR TITLE
TDS-1747: remove the test package status entry if we fail validate step

### DIFF
--- a/shared/src/main/java/tds/support/tool/services/impl/TestPackageJobServiceImpl.java
+++ b/shared/src/main/java/tds/support/tool/services/impl/TestPackageJobServiceImpl.java
@@ -107,6 +107,9 @@ public class TestPackageJobServiceImpl implements TestPackageJobService {
                                     .filter(nonValidationSteps -> nonValidationSteps.getJobStepTarget() != TargetSystem.Internal)
                                     .forEach(nonValidationSteps -> nonValidationSteps.setStatus(Status.FAIL));
 
+                            // TDS-1747: remove the test package status entry if we fail validate step
+                            testPackageStatusService.delete(job.getName());
+
                             jobRepository.save(job);
                             throw new RuntimeException("Error: The test package failed validation. Aborting test package load.");
                         } else if (step.getName().equals(TestPackageLoadJob.TDS_UPLOAD) && step.getStatus() == Status.FAIL) {


### PR DESCRIPTION
Some assessments pass the initial validation in the upload step, but fail in the validate step. For these, we weren't removing the package load status entry.